### PR TITLE
Fix compiletest error expectation strings.

### DIFF
--- a/tests/compile-fail/cannot-leak-scope.rs
+++ b/tests/compile-fail/cannot-leak-scope.rs
@@ -19,7 +19,7 @@ fn yield_() -> usize {
 
         let w = d(z);
     };
-    e(w); //~ ERROR error: unresolved name `w`. Did you mean `x`
+    e(w); //~ ERROR unresolved name `w`. Did you mean `x`
 }
 
 fn main() {

--- a/tests/compile-fail/dont-delete-unreachable-statements.rs
+++ b/tests/compile-fail/dont-delete-unreachable-statements.rs
@@ -11,7 +11,7 @@ fn gen<'a, T>(items: &'a [T]) -> &'a T {
             }
             None => {
                 break;
-                let x = y; //~ ERROR error: unresolved name `y`
+                let x = y; //~ ERROR unresolved name `y`
             }
         };
     };


### PR DESCRIPTION
rustc 1.11.0 (and perhaps earlier versions as well) does not prefix error messages with 'error: ' anymore.