### PR TITLE
Update compiler version and fix breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-- nightly
+- nightly-2016-09-01
 addons:
   apt:
     packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ impl_trait = []
 unstable-testing = ["clippy", "compiletest_rs"]
 
 [dependencies]
-aster = "^0.24.0"
+aster = "^0.26.0"
 clippy = { version = "0.0.83", optional = true }
 compiletest_rs = { version = "^0.2.1", optional = true }

--- a/src/mar/build/mod.rs
+++ b/src/mar/build/mod.rs
@@ -29,9 +29,9 @@ pub struct Error;
 pub fn construct(cx: &ExtCtxt, item: P<ast::Item>) -> Result<Mar, Error> {
     let item = simplify_item(item);
 
-    let (fn_decl, unsafety, constness, abi, generics, ast_block) = match item.node {
-        ItemKind::Fn(fn_decl, unsafety, constness, abi, generics, block) => {
-            (fn_decl, unsafety, constness, abi, generics, block)
+    let (fn_decl, unsafety, abi, generics, ast_block) = match item.node {
+        ItemKind::Fn(fn_decl, unsafety, _, abi, generics, block) => {
+            (fn_decl, unsafety, abi, generics, block)
         }
 
         _ => {
@@ -90,7 +90,6 @@ pub fn construct(cx: &ExtCtxt, item: P<ast::Item>) -> Result<Mar, Error> {
         span: item.span,
         fn_decl: fn_decl.clone(),
         unsafety: unsafety,
-        constness: constness,
         abi: abi,
         generics: generics.clone(),
         input_decls: live_decls,

--- a/src/mar/repr.rs
+++ b/src/mar/repr.rs
@@ -14,7 +14,6 @@ pub struct Mar {
 
     pub fn_decl: P<ast::FnDecl>,
     pub unsafety: ast::Unsafety,
-    pub constness: ast::Constness,
     pub abi: abi::Abi,
     pub generics: ast::Generics,
 


### PR DESCRIPTION
- Update compiler to 2016-09-01
- Lock this version in travis.yml
- Upgrade aster to 0.26.0
- Remove `constness` from Mar, since it is not used and easy to add if needed (and it broke compilation).
